### PR TITLE
Update gh workflow branch to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,28 +2,28 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v2
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-        
-    - name: Config Git
-      run: |
-        git config --global user.email "${{github.actor}}@users.noreply.github.com"
-        git config --global user.name "${{github.actor}}"
-        git remote set-url origin "https://${{github.actor}}:${{github.token}}@github.com/${{github.repository}}.git/"
-    
-    - name: Install
-      run: npm install
-    
-    - name: Build and Deploy
-      run: npm run deploy
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Config Git
+        run: |
+          git config --global user.email "${{github.actor}}@users.noreply.github.com"
+          git config --global user.name "${{github.actor}}"
+          git remote set-url origin "https://${{github.actor}}:${{github.token}}@github.com/${{github.repository}}.git/"
+
+      - name: Install
+        run: npm install
+
+      - name: Build and Deploy
+        run: npm run deploy


### PR DESCRIPTION
Workflow for deploying site will trigger on pushes to `main` branch instead of `master` (which has been deleted)